### PR TITLE
Support Universal builds for macOS

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -8,8 +8,16 @@
 	},
 	"files": ["dist-electron/**/*", "dist/**/*", "build/**/*", "public/**/*"],
 	"mac": {
-		"artifactName": "${productName}_${version}.${ext}",
-		"target": ["dmg", "zip"]
+		"artifactName": "${productName}_${version}_${arch}.${ext}",
+		"target": [
+			{
+				"target": "default",
+				"arch": [
+				  "x64",
+				  "arm64"
+				]
+			}
+		]
 	},
 	"win": {
 		"target": [


### PR DESCRIPTION
Hi, thanks for the awesome work!

I found that your releases was only build on Apple Sillicon Chips, which are not supported by previously Intel-chip Macs.

Therefore I modified the electron build configuration file, in order to support universal builds in orders to build Apple Sillicon (M1/M2) releases and Intel (amd64) release in the build process, which may suitable to future users' needs.