### PR TITLE
fix: dark mode compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
 	<head>
 		<meta charset="UTF-8" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 /** @type {import("tailwindcss").Config} */
 module.exports = {
 	content: ["./ui/**/*.{js,jsx,ts,tsx}", "./public/index.html"],
-	darkMode: "media",
+	darkMode: "class",
 	theme: {
 		extend: {
 			opacity: {


### PR DESCRIPTION
To solve the problem addressed in #11 .
It can be simply fixed by locking the apperence to "DARK MODE" if the app wasn't ready yet for light mode.

Tested works fine in light mode

<img width="1354" alt="image" src="https://github.com/postllm/postllm-app/assets/14831358/643f9092-7ee9-43ef-a466-0cc6e3ae108c">
