### PR TITLE
Add support to custom OpenAI Hosts

### DIFF
--- a/electron/models/config.ts
+++ b/electron/models/config.ts
@@ -15,6 +15,7 @@ export const schema = BaseModelSchema.extend({
 	licenseValid: z.boolean().default(false),
 	apiKeys: z.object({
 		openAIKey: z.string().optional(),
+		openAIEndpoint: z.string().url().optional(),
 	}),
 });
 

--- a/ui/components/Modals/SettingsModal.tsx
+++ b/ui/components/Modals/SettingsModal.tsx
@@ -134,6 +134,37 @@ const ApiKeysTab = () => {
 						</a>
 					</p>
 				</div>
+				<div className="mt-2">
+					<label
+						htmlFor="openaihost"
+						className="block text-sm font-medium leading-6 text-white"
+					>
+						OpenAI API Endpoint
+					</label>
+					<div className="mt-2">
+						<input
+							defaultValue={config?.apiKeys?.openAIEndpoint ?? ""}
+							type="text"
+							name="openaihost"
+							id="openaihost"
+							className="block w-full px-2 rounded-md border-0 py-1.5 text-black shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+							placeholder="https://api.openai.com"
+							aria-describedby="openai-description"
+							onChange={(e) => {
+								updateConfig({
+									...config,
+									apiKeys: {
+										...config?.apiKeys,
+										openAIEndpoint: e.target.value,
+									},
+								});
+							}}
+						/>
+					</div>
+					{config?.apiKeys?.openAIEndpoint ? (<p className="mt-2 text-xs" id="openai-description">
+						Your API key and all messages will be sent to {config?.apiKeys?.openAIEndpoint}. Please confirm that you trust this address. Otherwise, your apiKey could be exposed.
+					</p>) : null}
+				</div>
 			</div>
 		</>
 	);


### PR DESCRIPTION
Solve #12 .

Strategy:
1. Adding config property `Config#apiKeys#openAIEndpoint`, restrict to ZodURL type.
2. Customize OpenAI Bearer Config when using Langchain ChatOpenAI if user configured custom endpoints, otherwise return undefined.
3. Add Input and warning field in SettingsModal, allow user to customize custom endpoints by input specific URL, alongside with an API Leakage warning.